### PR TITLE
Removed unnecessary unnecessary workaround for avoiding copying Livy's jar to cluster fs.

### DIFF
--- a/apps/spark/java/livy-server/src/main/scala/com/cloudera/hue/livy/server/interactive/InteractiveSessionProcess.scala
+++ b/apps/spark/java/livy-server/src/main/scala/com/cloudera/hue/livy/server/interactive/InteractiveSessionProcess.scala
@@ -71,7 +71,7 @@ object InteractiveSessionProcess extends Logging {
     builder.redirectOutput(Redirect.PIPE)
     builder.redirectErrorStream(true)
 
-    builder.start(AbsolutePath("local://" + livyJar(livyConf)), List(createInteractiveRequest.kind.toString))
+    builder.start(AbsolutePath(livyJar(livyConf)), List(createInteractiveRequest.kind.toString))
   }
 
   private def livyJar(conf: LivyConf): String = {

--- a/apps/spark/java/livy-server/src/main/scala/com/cloudera/hue/livy/server/interactive/InteractiveSessionYarn.scala
+++ b/apps/spark/java/livy-server/src/main/scala/com/cloudera/hue/livy/server/interactive/InteractiveSessionYarn.scala
@@ -68,7 +68,8 @@ object InteractiveSessionYarn {
 
     builder.redirectOutput(Redirect.PIPE)
     builder.redirectErrorStream(true)
-    val process = builder.start(AbsolutePath("local://" + livyJar(livyConf)), List(kind, url))
+
+    val process = builder.start(AbsolutePath(livyJar(livyConf)), List(kind, url))
 
     new InteractiveSessionYarn(id, client, process, createInteractiveRequest)
   }


### PR DESCRIPTION
We should set livy.yarn.jar in config instead.
